### PR TITLE
Fix linter issues

### DIFF
--- a/cmd/vsphere-monitor/flags.go
+++ b/cmd/vsphere-monitor/flags.go
@@ -3,7 +3,7 @@ package main
 import "github.com/urfave/cli"
 
 var (
-	Flags = []cli.Flag{
+	flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "vsphere-url",
 			Usage:  "vSphere SDK URL, e.g. https://admin:password@192.0.2.1/sdk",

--- a/cmd/vsphere-monitor/main.go
+++ b/cmd/vsphere-monitor/main.go
@@ -39,7 +39,7 @@ func main() {
 	app.Author = "Travis CI GmbH"
 	app.Email = "contact+vsphere-monitor@travis-ci.org"
 
-	app.Flags = Flags
+	app.Flags = flags
 	app.Action = mainAction
 
 	err := app.Run(os.Args)
@@ -88,17 +88,17 @@ func mainAction(c *cli.Context) error {
 
 	libratoClient := vspheremonitor.NewLibratoClient(c.String("librato-email"), c.String("librato-token"))
 
-	alertIdMetricNameMap := make(map[string]string, len(c.StringSlice("vsphere-host-alert-id-metric-name")))
-	for _, alertIdMetricName := range c.StringSlice("vsphere-host-alert-id-metric-name") {
-		parts := strings.SplitN(alertIdMetricName, ":", 2)
-		alertIdMetricNameMap[parts[0]] = parts[1]
+	alertIDMetricNameMap := make(map[string]string, len(c.StringSlice("vsphere-host-alert-id-metric-name")))
+	for _, alertIDMetricName := range c.StringSlice("vsphere-host-alert-id-metric-name") {
+		parts := strings.SplitN(alertIDMetricName, ":", 2)
+		alertIDMetricNameMap[parts[0]] = parts[1]
 	}
 
 	ticker := time.Tick(time.Minute)
 
 	for now := range ticker {
-		metrics := make(map[string]map[string]int64, len(alertIdMetricNameMap))
-		for _, metricName := range alertIdMetricNameMap {
+		metrics := make(map[string]map[string]int64, len(alertIDMetricNameMap))
+		for _, metricName := range alertIDMetricNameMap {
 			metrics[metricName] = make(map[string]int64)
 		}
 
@@ -113,7 +113,7 @@ func mainAction(c *cli.Context) error {
 				}
 
 				for alarmID, state := range alarmStates {
-					metricName, ok := alertIdMetricNameMap[alarmID]
+					metricName, ok := alertIDMetricNameMap[alarmID]
 					if !ok {
 						continue
 					}

--- a/host_alarm_reporter.go
+++ b/host_alarm_reporter.go
@@ -1,0 +1,117 @@
+package vspheremonitor
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var alarmStateToMetricValueMap = map[string]int64{
+	"green":  0,
+	"yellow": 1,
+	"red":    2,
+}
+
+// HostAlarmReporter reports the current state of alarms for hosts to Librato
+type HostAlarmReporter struct {
+	LibratoClient        *LibratoClient
+	VSphereClient        *VSphereClient
+	AlarmIDMetricNameMap map[string]string
+	Clusters             map[string][]*VSphereHost
+}
+
+// SetClusterPaths populatest the Clusters attribute of the HostAlarmReporter
+// by fetching all the hosts in the clusters with the given inventory paths.
+// Note that full inventory paths are required, for example
+// "/my-datacenter/host/my-cluster".
+func (har *HostAlarmReporter) SetClusterPaths(ctx context.Context, logger logrus.FieldLogger, clusterPaths []string) error {
+	logger.Info("getting list of hosts")
+
+	hostCount := 0
+	clusters := make(map[string][]*VSphereHost, len(clusterPaths))
+	for _, clusterPath := range clusterPaths {
+		clusterName := path.Base(clusterPath)
+
+		logger.WithField("cluster_name", clusterName).WithField("cluster_path", clusterPath).Info("getting list of hosts in cluster")
+		hosts, err := har.VSphereClient.ListHostsInCluster(ctx, clusterPath)
+		if err != nil {
+			return errors.Wrapf(err, "error listing hosts in cluster %s (path %s)", clusterName, clusterPath)
+		}
+
+		clusters[clusterName] = hosts
+		hostCount += len(hosts)
+	}
+	logger.WithField("host_count", hostCount).Info("found hosts")
+
+	har.Clusters = clusters
+	return nil
+}
+
+// Report fetches the state of all alarms in the hosts in the Clusters
+// attribute, and reports their state to Librato.
+func (har *HostAlarmReporter) Report(ctx context.Context, logger logrus.FieldLogger) {
+	metrics := har.getMetrics(ctx, logger)
+	libratoMetrics := har.convertToLibratoMeasurements(ctx, logger, metrics)
+
+	err := har.LibratoClient.SubmitMeasurements(libratoMetrics)
+	if err != nil {
+		logger.WithError(err).Error("couldn't submit metrics to Librato")
+		return
+	}
+
+	logger.WithField("measurement_count", len(libratoMetrics.Gauges)).Info("sent measurements to Librato")
+}
+
+func (har *HostAlarmReporter) getMetrics(ctx context.Context, logger logrus.FieldLogger) map[string]map[string]int64 {
+	metrics := make(map[string]map[string]int64, len(har.AlarmIDMetricNameMap))
+	for _, metricName := range har.AlarmIDMetricNameMap {
+		metrics[metricName] = make(map[string]int64)
+	}
+
+	for clusterName, hosts := range har.Clusters {
+		for _, host := range hosts {
+			metricSource := clusterName + "-" + host.Name()
+
+			alarmStates, err := har.VSphereClient.ListAlarmStatesForHost(ctx, host)
+			if err != nil {
+				logger.WithField("cluster_name", clusterName).WithField("host", host.Name()).WithError(err).Error("error getting alarm states for host")
+				continue
+			}
+
+			for alarmID, state := range alarmStates {
+				metricValue, ok := alarmStateToMetricValueMap[state]
+				if ok {
+					metrics[alarmID][metricSource] = metricValue
+				}
+			}
+		}
+	}
+
+	return metrics
+}
+
+func (har *HostAlarmReporter) convertToLibratoMeasurements(ctx context.Context, logger logrus.FieldLogger, metrics map[string]map[string]int64) LibratoMeasurements {
+	var libratoMetrics LibratoMeasurements
+	libratoMetrics.MeasureTime = time.Now().Unix()
+
+	for alarmID, sourceVals := range metrics {
+		for source, value := range sourceVals {
+			metricName, ok := har.AlarmIDMetricNameMap[alarmID]
+			if !ok {
+				continue
+			}
+
+			libratoMetrics.Gauges = append(libratoMetrics.Gauges, LibratoGauge{
+				Name:   fmt.Sprintf("travis.vsphere-monitor.host-alarm.%s", metricName),
+				Value:  float64(value),
+				Source: source,
+			})
+		}
+	}
+
+	return libratoMetrics
+}

--- a/librato.go
+++ b/librato.go
@@ -8,11 +8,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+// A LibratoClient allows for submitting measurements to Librato using the
+// Librato API. It only supports accounts using the "legacy" source-based
+// metrics, tag-based metrics are not supported.
 type LibratoClient struct {
 	client       *http.Client
 	email, token string
 }
 
+// NewLibratoClient creates a new LibratoClient using the given email and
+// token. The token needs to be associated with the Librato account with the
+// given email and needs to have record permissions.
 func NewLibratoClient(email, token string) *LibratoClient {
 	return &LibratoClient{
 		client: new(http.Client),
@@ -21,6 +27,8 @@ func NewLibratoClient(email, token string) *LibratoClient {
 	}
 }
 
+// SubmitMeasurements submits a list of measurements to Librato. All fields in
+// the given structure are required.
 func (lc *LibratoClient) SubmitMeasurements(measurements LibratoMeasurements) error {
 	body, err := json.Marshal(measurements)
 	if err != nil {
@@ -39,13 +47,30 @@ func (lc *LibratoClient) SubmitMeasurements(measurements LibratoMeasurements) er
 	return errors.Wrap(err, "error while sending HTTP request")
 }
 
+// LibratoMeasurements contains a set of metric measurements taken at a given
+// timestamp, to be submitted to Librato using
+// LibratoClient.SubmitMeasurements.
 type LibratoMeasurements struct {
-	MeasureTime int64          `json:"measure_time"`
-	Gauges      []LibratoGauge `json:"gauges"`
+	// MeasureTime is the unix timestamp for when the measurements were taken
+	MeasureTime int64 `json:"measure_time"`
+
+	// Gauges is a list of gauge measurements.
+	Gauges []LibratoGauge `json:"gauges"`
 }
 
+// LibratoGauge contains an individual gauge measurement.
 type LibratoGauge struct {
-	Name   string  `json:"name"`
-	Value  float64 `json:"value"`
-	Source string  `json:"source"`
+	// Name is the name of the metric the measurement is associated with. The
+	// name must be 255 or fewer characters, and may only consist of
+	// 'A-Za-z0-9.:-_'.
+	Name string `json:"name"`
+
+	// Value is the current value of the measurement, as of the time specified
+	// in MeasureTime in the LibratoMeasurement structure.
+	Value float64 `json:"value"`
+
+	// Source is a name describing the originating source of the measurement.
+	// The source name must be 255 or fewer characters, and may only consist of
+	// 'A-Za-z0-9.:-_'.
+	Source string `json:"source"`
 }


### PR DESCRIPTION
Some smaller and larger linter-driven fixes

The largest is the moving of things into HostAlarmReporter in order to make it easier to extract more things into named functions instead of having a massive `main`.