### PR TITLE
Add configurable Librato source prefix

### DIFF
--- a/cmd/vsphere-monitor/flags.go
+++ b/cmd/vsphere-monitor/flags.go
@@ -34,5 +34,10 @@ var (
 			Usage:  "Librato token (with record permissions) associated with the Librato account to send metrics to",
 			EnvVar: "VSPHERE_MONITOR_LIBRATO_TOKEN,LIBRATO_TOKEN",
 		},
+		cli.StringFlag{
+			Name:   "librato-source-prefix",
+			Usage:  "Prefix to prepent to all Librato source names",
+			EnvVar: "VSPHERE_MONITOR_LIBRATO_SOURCE_PREFIX,LIBRATO_SOURCE_PREFIX",
+		},
 	}
 )

--- a/cmd/vsphere-monitor/main.go
+++ b/cmd/vsphere-monitor/main.go
@@ -68,7 +68,7 @@ func mainAction(c *cli.Context) error {
 	}
 
 	har := vspheremonitor.HostAlarmReporter{
-		LibratoClient:        vspheremonitor.NewLibratoClient(c.String("librato-email"), c.String("librato-token")),
+		LibratoClient:        vspheremonitor.NewLibratoClient(c.String("librato-email"), c.String("librato-token"), c.String("librato-source-prefix")),
 		VSphereClient:        vSphereClient,
 		AlarmIDMetricNameMap: kvSliceToMap(c.StringSlice("vsphere-host-alert-id-metric-name"), ":"),
 	}

--- a/librato.go
+++ b/librato.go
@@ -12,24 +12,29 @@ import (
 // Librato API. It only supports accounts using the "legacy" source-based
 // metrics, tag-based metrics are not supported.
 type LibratoClient struct {
-	client       *http.Client
-	email, token string
+	client                     *http.Client
+	email, token, sourcePrefix string
 }
 
 // NewLibratoClient creates a new LibratoClient using the given email and
 // token. The token needs to be associated with the Librato account with the
 // given email and needs to have record permissions.
-func NewLibratoClient(email, token string) *LibratoClient {
+func NewLibratoClient(email, token, sourcePrefix string) *LibratoClient {
 	return &LibratoClient{
-		client: new(http.Client),
-		email:  email,
-		token:  token,
+		client:       new(http.Client),
+		email:        email,
+		token:        token,
+		sourcePrefix: sourcePrefix,
 	}
 }
 
 // SubmitMeasurements submits a list of measurements to Librato. All fields in
 // the given structure are required.
 func (lc *LibratoClient) SubmitMeasurements(measurements LibratoMeasurements) error {
+	for i := range measurements.Gauges {
+		measurements.Gauges[i].Source = lc.sourcePrefix + measurements.Gauges[i].Source
+	}
+
 	body, err := json.Marshal(measurements)
 	if err != nil {
 		return errors.Wrap(err, "error marshalling measurements to JSON")


### PR DESCRIPTION
This prefix can be used to identify a given vsphere-monitor instance in the metrics, which makes it easier to determine which pod a given metric source is attached to.

Resolves #6.