### PR TITLE
Fix panic in HostAlarmReporter

### DIFF
--- a/host_alarm_reporter.go
+++ b/host_alarm_reporter.go
@@ -69,10 +69,6 @@ func (har *HostAlarmReporter) Report(ctx context.Context, logger logrus.FieldLog
 
 func (har *HostAlarmReporter) getMetrics(ctx context.Context, logger logrus.FieldLogger) map[string]map[string]int64 {
 	metrics := make(map[string]map[string]int64, len(har.AlarmIDMetricNameMap))
-	for _, metricName := range har.AlarmIDMetricNameMap {
-		metrics[metricName] = make(map[string]int64)
-	}
-
 	for clusterName, hosts := range har.Clusters {
 		for _, host := range hosts {
 			metricSource := clusterName + "-" + host.Name()
@@ -87,6 +83,9 @@ func (har *HostAlarmReporter) getMetrics(ctx context.Context, logger logrus.Fiel
 			for alarmID, state := range alarmStates {
 				metricValue, ok := alarmStateToMetricValueMap[state]
 				if ok {
+					if _, ok := metrics[alarmID]; !ok {
+						metrics[alarmID] = make(map[string]int64)
+					}
 					metrics[alarmID][metricSource] = metricValue
 				}
 			}


### PR DESCRIPTION
At some point we changed from using metric names to alarm IDs in this map, but the code to set up the second-level maps wasn't changed, causing it to panic with "assigning to entry in nil map" errors on the line

``` Go
metrics[alarmID][metricSource] = metricValue
```